### PR TITLE
feat: Update protected route HOC

### DIFF
--- a/src/api/user.js
+++ b/src/api/user.js
@@ -12,7 +12,6 @@ function getUser({ userId, token }) {
   const url = new URL(process.env.REACT_APP_API_HOST);
   url.pathname = '/api/v1/users';
   url.searchParams.append('auth0_id', userId);
-  console.log(userId, token, url);
   const results = fetch(url, {
     method: 'GET',
     mode: 'cors',

--- a/src/auth/auth0-provider-with-history.js
+++ b/src/auth/auth0-provider-with-history.js
@@ -24,6 +24,8 @@ const Auth0ProviderWithHistory = ({ children }) => {
       audience="https://nbjc-app/api"
       scope="openid profile write:spaces"
       onRedirectCallback={onRedirectCallback}
+      cacheLocation="localstorage"
+      useRefreshTokens
     >
       {children}
     </Auth0Provider>

--- a/src/components/AppBar/AppBar.jsx
+++ b/src/components/AppBar/AppBar.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useContext } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import { useHistory, useLocation } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 
 import { withStyles } from '@material-ui/core';
 
@@ -55,7 +55,7 @@ const AppBar = ({
   const [showDrawer, setShowDrawer] = useState(false);
   const nameContext = useContext(NameContext);
   const history = useHistory();
-  const location = useLocation();
+  // const location = useLocation();
 
   const pageTitle = (routes.find((item) => item.key === selected) || {}).label;
 
@@ -98,8 +98,7 @@ const AppBar = ({
   const NavIcons = () => {
     let appIcons;
     if (
-      (location && location.search.length > 0)
-      || selected === 'spaceDetails'
+      selected === 'spaceDetails'
       || selected === 'addReview'
       || selected === 'reviews'
     ) {

--- a/src/routes/ProtectedRoute.jsx
+++ b/src/routes/ProtectedRoute.jsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from 'react';
+import { withAuthenticationRequired, useAuth0 } from '@auth0/auth0-react';
+import CircularProgress from '@material-ui/core/CircularProgress';
+
+const ProtectedRoute = (component) => (props) => {
+  const { isAuthenticated, getAccessTokenSilently } = useAuth0();
+  let token;
+  const [authStatus, setAuthStatus] = useState(null);
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setAuthStatus('fetching');
+        token = await getAccessTokenSilently();
+        setAuthStatus('authenticated');
+      } catch (err) {
+        setAuthStatus('notAuthenticated');
+      }
+    };
+    fetchData();
+  }, [token]);
+  let Component = component;
+  if (authStatus === null || authStatus === 'fetching') {
+    return <CircularProgress color="secondary" />;
+  }
+  if (isAuthenticated || authStatus === 'authenticated') {
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    return <Component {...props} />;
+  }
+  Component = withAuthenticationRequired(component, {
+    // eslint-disable-next-line react/react-in-jsx-scope
+    onRedirecting: () => <div>Redirecting you to the login page...</div>,
+  });
+  // eslint-disable-next-line react/jsx-props-no-spreading
+  return <Component {...props} />;
+};
+
+export default ProtectedRoute;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -3,7 +3,6 @@ import SearchIcon from '@material-ui/icons/Search';
 import AddCircleOutlineIcon from '@material-ui/icons/AddCircleOutline';
 import PersonOutlineIcon from '@material-ui/icons/PersonOutline';
 
-import { withAuthenticationRequired } from '@auth0/auth0-react';
 import Home from './Home';
 import Search from './Search';
 import AddSpace from './AddSpace';
@@ -12,10 +11,7 @@ import SpaceDetails from './SpaceDetails';
 import Reviews from './Reviews';
 import CreateProfile from './CreateProfile';
 
-const ProtectedRoute = (component) => withAuthenticationRequired(component, {
-  // eslint-disable-next-line react/react-in-jsx-scope
-  onRedirecting: () => <div>Redirecting you to the login page...</div>,
-});
+import ProtectedRoute from './ProtectedRoute';
 
 const routes = [{
   label: 'Home',


### PR DESCRIPTION
**What**
---
* Updates Protected route HOC to only redirect to login page when there is no token present.

**Why**
---
This is to make sure, when the user lands on a protected route, if they were already logged in recently (AuthO tokens are valid for 10 Hours), they are directly taken to the page instead of having to do the OAuth dance again.

**How**
---
* By using Auth0's [refresh tokens](https://auth0.com/docs/libraries/auth0-single-page-app-sdk#use-rotating-refresh-tokens) and [localstorage](https://auth0.com/docs/libraries/auth0-single-page-app-sdk#change-storage-options), the tokens are remembered locally in the browser by auth0
* When a user visits a Protected Page, the app first tries to get the token silently (aka without a popup)
* If the above step succeeds, the user is redirected to the component page directly.
* Else, the user is redirected to login using the `withAuthenticationRequired` HOC provided by AuthO
