### PR TITLE
fix: Show a loading state when redirecting from login

### DIFF
--- a/src/components/AppBar/AppBar.jsx
+++ b/src/components/AppBar/AppBar.jsx
@@ -80,6 +80,7 @@ const AppBar = ({
   selected,
   classes,
   routes,
+  isLoading,
 }) => {
   const [showDrawer, setShowDrawer] = useState(false);
   const [showSupportDialog, setShowSupportDialog] = useState(false);
@@ -180,9 +181,9 @@ const AppBar = ({
           <Toolbar>
             <NavIcons />
             <Typography variant="h6" data-testid="appbar-title">
-              {pageTitle || nameContext.spaceTitle}
+              {isLoading ? '' : pageTitle || nameContext.spaceTitle}
             </Typography>
-            {pageTitle !== 'undefined' && pageTitle === 'Home' ? <Logo /> : null}
+            {pageTitle !== 'undefined' && pageTitle === 'Home' && !isLoading ? <Logo /> : null}
             <Avatar className={classes.avatar}>
               <Link href="/profile" underline="none">
                 {avatar}
@@ -259,6 +260,7 @@ const AppBar = ({
 AppBar.propTypes = {
   selected: PropTypes.string,
   classes: PropTypes.shape({}).isRequired,
+  isLoading: PropTypes.bool,
   routes: PropTypes.arrayOf(
     PropTypes.shape({
       label: PropTypes.string.isRequired,
@@ -270,6 +272,7 @@ AppBar.propTypes = {
 
 AppBar.defaultProps = {
   selected: 'home',
+  isLoading: false,
 };
 
 export default withStyles(styles)(AppBar);

--- a/src/components/AppLayout/AppLayout.jsx
+++ b/src/components/AppLayout/AppLayout.jsx
@@ -1,7 +1,8 @@
 /* eslint-disable arrow-body-style */
 import React from 'react';
-// import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
+import { useAuth0 } from '@auth0/auth0-react';
+import CircularProgress from '@material-ui/core/CircularProgress';
 
 import AppBar from '../AppBar';
 import Footer from '../Footer';
@@ -39,14 +40,23 @@ const AppLayout = ({
       key: r.key,
       icon: r.icon,
     }));
+  const { isLoading } = useAuth0();
   return (
     <div className={classes.root}>
       <AppBar
         routes={appBarRoutes}
         selected={selected}
+        isLoading={isLoading}
       />
       <div className={classes.content}>
-        {children}
+        {isLoading && (
+          <CircularProgress color="secondary" />
+        )}
+        {!isLoading && (
+          <>
+            {children}
+          </>
+        )}
       </div>
       <Footer />
     </div>

--- a/src/components/ProfilePage/ProfilePage.jsx
+++ b/src/components/ProfilePage/ProfilePage.jsx
@@ -398,7 +398,7 @@ const ProfilePage = ({ classes }) => {
         className={classes.submitButton}
         variant="contained"
         onClick={() => logout({
-          returnTo: `http://${process.env.REACT_APP_DOMAIN}/`,
+          returnTo: window.location.origin,
           client_id: process.env.REACT_APP_AUTH0_CLIENT_ID,
           federated: `https://${process.env.REACT_APP_AUTH0_DOMAIN}/v2/logout?federated`,
         })}


### PR DESCRIPTION
**What**
---
Shows a loading state when redirecting from login.


**How**
---
When redirecting from Auth0, there is a momentary loading state which is captured in the `isLoading` state value provided by Auth0's custom hook. (See the **isLoading** example in [Auth0's doc](https://auth0.com/blog/complete-guide-to-react-user-authentication/)
![2021-05-14 16 05 51](https://user-images.githubusercontent.com/1613526/118323244-54914000-b4ce-11eb-9cd6-27c8afa6f23c.gif)

