### PR TITLE
the api host is already set from the env file or DigitalOcean

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "web-vitals": "^0.2.4"
   },
   "scripts": {
-    "start": "REACT_APP_API_HOST=https://api.lavenderbook.org react-scripts start",
+    "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",


### PR DESCRIPTION
# Description

The API host should not be configured when running the `start` script, which is usually only run during local development. It should be set as environment variable either from an env file locally or from DigitalOcean.

Fixes # (issue)
Hitting the wrong API and wrong auth tenant when doing local development.

**Before**
Sets the default API host as the production API.

**After**
Allows you to set the API host via your local env file.

## Type of change
package.json - start script

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Dependency Changes
n/a

# How Has This Been Tested?
API host set through a local .env file, ran `yarn start` and frontend hits the API specified in env file.