### PR TITLE
Fix hours of operation check

### DIFF
--- a/src/utils/formatHoursOfOperation.js
+++ b/src/utils/formatHoursOfOperation.js
@@ -13,9 +13,13 @@ const formatHoursOfOperation = (hoursOfOperation) => {
   const currentDate = new Date();
   const currentDay = currentDate.getDay();
   const currentTime = currentDate.getHours() * 100;
-  if (parseInt(hoursOfOperation.open[currentDay].start, 10)
+  const currentDayHours = hoursOfOperation.open.find((hop) => hop.day === currentDay);
+  if (!currentDayHours) {
+    return false;
+  }
+  if (parseInt(currentDayHours.start, 10)
   <= currentTime
-  <= parseInt(hoursOfOperation.open[currentDay].end, 10)) {
+  <= parseInt(currentDayHours.end, 10)) {
     return true;
   }
   return false;


### PR DESCRIPTION
# Description

While checking the hours of operation, we were purely relying on the array index. But yelp returns an array of objects with only the days the place is open in it. This change includes looking into the array to see if a matching date to `today` is found and only then check the start and end times for it. 


Fixes # (issue)

## Screenshots
**Hours of operation as returned by yelp**
![image](https://user-images.githubusercontent.com/1613526/138567692-6452bc48-e628-4cc8-a3bc-629c6b4ff7ad.png)


**Before**
![image](https://user-images.githubusercontent.com/1613526/138567654-4682ad7c-c40d-4b15-81e2-c209ae77187b.png)

**After**
![image](https://user-images.githubusercontent.com/1613526/138567657-daf0da0f-2469-4a5d-9ccf-b09f5bb485a6.png)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Dependency Changes
 None

# How Has This Been Tested?

By locally adding the space which was returning a 500 in prod and verifying that it shows up now. 
https://lavenderbook.org/spaces/65