### PR TITLE
review shows up now

### DIFF
--- a/src/components/AddSpacePage/Submit.jsx
+++ b/src/components/AddSpacePage/Submit.jsx
@@ -62,11 +62,7 @@ const Submit = ({
       </Typography>
       <div className={classes.section}>
         <div className={classes.sectionHeader}>
-          <Typography
-            variant="h6"
-            align="center"
-            className={classes.sectionTitle}
-          >
+          <Typography variant="body2">
             Space Details
           </Typography>
           <EditIcon
@@ -114,6 +110,15 @@ const Submit = ({
           />
         </div>
         <StarRating numberFilled={addSpaceProps.rating} editable={false} />
+        <div>
+          <Typography
+            variant="h6"
+            align="center"
+            className={classes.sectionTitle}
+          >
+            {addSpaceProps.review}
+          </Typography>
+        </div>
       </div>
       <div className={classes.footer}>
         <Button


### PR DESCRIPTION
# Description

Original issue: [BUG] When reviewing details to add a space, it does not show me the review I wrote just the rating #51

Fixes # (issue)
![write review](https://user-images.githubusercontent.com/66184393/146663632-8422762f-c8af-4bab-85f0-cedd41745c70.png)

## Screenshots

__Ad screenshots of the changes if relevant__
![review submit](https://user-images.githubusercontent.com/66184393/146663636-1edc5cfc-05f4-4ead-846a-08f81f219ef3.png)


**Before**
when a user enters a review and goes to Submit screen, they were only seeing the star rating but not the written review.
![before fix](https://user-images.githubusercontent.com/66184393/146663761-f7138bb0-9c98-470e-b526-47ddbd0a0834.png)

**After**
the written review is displayed under the star rating.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Dependency Changes
* Please list any dependency changes and why they were required

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B