### PR TITLE
DEV-101: setup google analytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,10 +13,8 @@
 
 # misc
 .DS_Store
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*
+!.env
 
 npm-debug.log*
 yarn-debug.log*

--- a/public/index.html
+++ b/public/index.html
@@ -24,6 +24,22 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script type="text/javascript" >
+      if( '%NODE_ENV%' === 'production') {
+	  var gscript = document.createElement('script');
+	  gscript.async = true
+	  gscript.src = "https://www.googletagmanager.com/gtag/js?id=%REACT_APP_GOOGLE_ANALYTICS%";
+	  var first = document.getElementsByTagName('script')[0];
+	  first.parentNode.insertBefore(gscript, first);
+      }
+    </script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', '%REACT_APP_GOOGLE_ANALYTICS%');
+    </script>
     <title>Lavender Book</title>
   </head>
   <body>


### PR DESCRIPTION
Script tag doesn't render proper closing tag by writing to document. Use vanilla js instead.

# Description

Properly render script tag for google analytics

Fixes #64 

## Type of change

Please delete options that are not relevant.
- [x ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Locally