### PR TITLE
Change icon for home location

### DIFF
--- a/src/components/SearchBar/SearchBar.jsx
+++ b/src/components/SearchBar/SearchBar.jsx
@@ -15,6 +15,8 @@ import {
 
 import SearchIcon from '@material-ui/icons/Search';
 import LocationOnIcon from '@material-ui/icons/LocationOn';
+import HomeIcon from '@material-ui/icons/Home';
+
 import Autocomplete, { createFilterOptions } from '@material-ui/lab/Autocomplete';
 
 import States from '../../api/states';
@@ -121,13 +123,15 @@ const SearchBar = ({
           filterOptions={filterOptions}
           renderOption={(props) => {
             const dropdownText = parseLocationObjectToString(props);
+            const dropdownIcon = location.trim() === '' ? <HomeIcon className={classes.icon} />
+              : <LocationOnIcon className={classes.icon} />;
             return (
               <Box
                 component="div"
                 sx={{ '& > img': { mr: 2, flexShrink: 0 } }}
                 className={classes.dropdown}
               >
-                <LocationOnIcon className={classes.icon} />
+                {dropdownIcon}
                 {dropdownText}
               </Box>
             );


### PR DESCRIPTION
# Description

The home location renders with a home icon instead of location icon.

The purpose of this change is to make it more obvious to the user that the autocomplete being rendered is the home location.

## Screenshots
**Before**
![chrome_hREeF7oXl0](https://user-images.githubusercontent.com/86702974/196001828-8a11c478-08a4-45a9-8d6b-5f348003bb0c.png)

**After**
![chrome_vJ66jDK73G](https://user-images.githubusercontent.com/86702974/196001830-fc768c92-108b-4a67-bea6-9831a8e458bd.png)


## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
Locally, testing it with location on/off, etc.