### PR TITLE
Fix: Update header to be more responsive

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -29,6 +29,7 @@ const styles = (theme) => ({
     alignItems: 'center',
     justifyContent: 'center',
     flexDirection: 'column',
+    width: '100%',
     [theme.breakpoints.up('xs')]: {
       margin: '0 20px',
     },
@@ -46,6 +47,7 @@ const styles = (theme) => ({
     fontWeight: 700,
     lineHeight: '1.235',
     marginBottom: '.6em',
+    width: 'auto',
   },
 });
 

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import { Box, Typography } from '@material-ui/core';
 import SearchBar from '../SearchBar';
-import useMobileDevice from '../../hooks/useMobileDevice';
 
 const styles = (theme) => ({
   root: {
@@ -14,8 +13,11 @@ const styles = (theme) => ({
       'linear-gradient(#633AA3CC, #633AA3CC), url("/landing.png")',
     backgroundPosition: 'center',
     backgroundSize: 'cover',
-    [theme.breakpoints.up('xs')]: {
+    [theme.breakpoints.down('xs')]: {
       height: 145,
+    },
+    [theme.breakpoints.up('xs')]: {
+      height: 190,
     },
     [theme.breakpoints.up('md')]: {
       height: 262,
@@ -29,30 +31,42 @@ const styles = (theme) => ({
     [theme.breakpoints.up('xs')]: {
       margin: '0 20px',
     },
-    [theme.breakpoints.up('mobile')]: {
+    [theme.breakpoints.up('sm')]: {
       margin: '0 100px',
     },
   },
+  title: {
+    [theme.breakpoints.up('xs')]: {
+      fontSize: '2.125rem',
+    },
+    [theme.breakpoints.down('sm')]: {
+      fontSize: '1.875rem',
+    },
+    [theme.breakpoints.down('xs')]: {
+      fontSize: '20.5px',
+    },
+    fontWeight: 700,
+    lineHeight: '1.235',
+    marginBottom: '.6em',
+  },
 });
 
-const Header = ({ classes }) => {
-  const [isMobileOrTablet] = useMobileDevice();
-  return (
-    <section>
-      <Box className={classes.root}>
-        <Box className={classes.container}>
-          <Typography
-            variant={isMobileOrTablet ? 'body1' : 'h4'}
-            gutterBottom
-          >
-            <b>Find spaces for Black Queer Folx</b>
-          </Typography>
-          <SearchBar />
-        </Box>
+const Header = ({ classes }) => (
+  <section>
+    <Box className={classes.root}>
+      <Box className={classes.container}>
+        <Typography
+          variant="h1"
+          gutterBottom
+          className={classes.title}
+        >
+          Find spaces for Black Queer Folx
+        </Typography>
+        <SearchBar />
       </Box>
-    </section>
-  );
-};
+    </Box>
+  </section>
+);
 
 Header.propTypes = {};
 

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -13,14 +13,15 @@ const styles = (theme) => ({
       'linear-gradient(#633AA3CC, #633AA3CC), url("/landing.png")',
     backgroundPosition: 'center',
     backgroundSize: 'cover',
-    [theme.breakpoints.down('xs')]: {
-      height: 145,
-    },
+
     [theme.breakpoints.up('xs')]: {
       height: 190,
     },
     [theme.breakpoints.up('md')]: {
       height: 262,
+    },
+    [theme.breakpoints.down('xs')]: {
+      height: 145,
     },
   },
   container: {
@@ -30,9 +31,6 @@ const styles = (theme) => ({
     flexDirection: 'column',
     [theme.breakpoints.up('xs')]: {
       margin: '0 20px',
-    },
-    [theme.breakpoints.up('sm')]: {
-      margin: '0 100px',
     },
   },
   title: {

--- a/src/components/Header/Header.test.jsx
+++ b/src/components/Header/Header.test.jsx
@@ -1,8 +1,19 @@
-// import React from 'react';
-// import { render } from '@testing-library/react';
+/*
+import React from 'react';
+import { render, screen } from '@testing-library/react';
 
-// import Header from './Header';
+import Header from './Header';
 
-// test('Header', () => {
-
-// });
+describe('Header Component', () => {
+  it('It should render a searchbar', () => {
+    render(<Header />);
+    const searchBar = screen.getByTestId('searchbar-submit');
+    expect(searchBar).toBeInTheDocument();
+  });
+  it('It should have an h1 element', () => {
+    const { container } = render(<Header />);
+    const h1Element = container.querySelector('h1');
+    expect(h1Element).toBeInTheDocument();
+  });
+});
+*/


### PR DESCRIPTION
**Merge notes: No dependencies to any other PR, can be merged as is.**

# Description

The purpose of this change is to update the header overall to be more responsive. When redesigning the homepage, I noticed the header could be more responsive. 

- Adjusted title text size based on breakpoints instead of user device to prevent text wrapping, 
- Height of header reduces more gradually to make the transition more smooth into mobile sizes.
- Increased line height slightly to provide extra margin between title and the search bar.


## Screenshots
All pictures are in decrementing widths.

**Before**
![chrome_RFxbufVCOa](https://user-images.githubusercontent.com/86702974/205790401-637df459-c615-4a09-9f2f-9b1ce2976867.png)
![chrome_TiQjTziWXi](https://user-images.githubusercontent.com/86702974/205790407-49953039-3b3f-46bd-8862-c8171419a2e0.png)
![chrome_KYrECriBYt](https://user-images.githubusercontent.com/86702974/205790412-be7f0c4b-fd3b-4b42-9088-10fb011a959a.png)
![chrome_TtyA4tatie](https://user-images.githubusercontent.com/86702974/205790417-512875a8-c87c-4589-a682-0e686e03f723.png)

**After**

![chrome_PBmirORtU2](https://user-images.githubusercontent.com/86702974/205789774-06d44d10-f143-4f5c-90de-c6f365d9f92f.png)
![chrome_f5KmfU2yW6](https://user-images.githubusercontent.com/86702974/205789782-2f1a28fc-db5f-4f2e-8be2-76929c7f0d94.png)
![chrome_jWQ6x8MFhq](https://user-images.githubusercontent.com/86702974/205789790-c78c553f-a525-4972-90d8-b544cb9cc9ff.png)
![chrome_l6d8hDrqRK](https://user-images.githubusercontent.com/86702974/205790062-15147e76-0173-4e79-bed0-c61ca67f9368.png)




## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Mostly CSS changes, so tested with manual testing. 