### PR TITLE
DEV-97.4: Add Report Problem Button in Results Page

### DIFF
--- a/src/components/Pagination/Pagination.jsx
+++ b/src/components/Pagination/Pagination.jsx
@@ -113,7 +113,7 @@ const styles = () => ({
     fontWeight: 500,
   },
   hideDisplay: {
-    display: 'none',
+    visibility: 'hidden',
   },
   buttonOpenGoToPage: {
     maxWidth: 28,
@@ -133,6 +133,11 @@ const styles = () => ({
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
+  },
+  alignPaginationRange: {
+    height: '100%',
+    display: 'flex',
+    justifyContent: 'center',
   },
 });
 
@@ -226,7 +231,7 @@ const RangeOfResults = (
     (totalCount > 0) && (desktopDimensions)
     && (
       <Typography variant="h5" align="center" className={classes.showingText}>
-        <span className={classes.centerText}>
+        <span className={classes.alignPaginationRange}>
           {calculateRange}
         </span>
       </Typography>

--- a/src/components/SupportButton/SupportButton.jsx
+++ b/src/components/SupportButton/SupportButton.jsx
@@ -1,0 +1,87 @@
+import React, { useState } from 'react';
+
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  withStyles,
+} from '@material-ui/core/';
+
+const styles = (theme) => ({
+  centerContent: {
+    display: 'flex',
+    justifyContent: 'center',
+  },
+  searchButton: {
+    [theme.breakpoints.up('lg')]: {
+      minWidth: 122.4,
+      minHeight: 40.8,
+    },
+    backgroundColor: '#FCFBFE',
+    textTransform: 'none',
+    border: '1px solid #EBE5F6',
+    fontWeight: 600,
+    marginBottom: 4,
+  },
+});
+
+const SupportButton = ({ classes }) => {
+  const [showSupportDialog, setShowSupportDialog] = useState(false);
+
+  return (
+    <Box>
+      <Box className={classes.centerContent} style={{ marginTop: '1rem' }}>
+        <Button
+          variant="outlined"
+          className={classes.searchButton}
+          onClick={() => {
+            setShowSupportDialog(true);
+          }}
+        >
+          Report a Problem
+        </Button>
+      </Box>
+      <Dialog
+        open={showSupportDialog}
+        onClose={() => setShowSupportDialog(false)}
+        aria-labelledby="alert-dialog-title"
+        aria-describedby="alert-dialog-description"
+      >
+        <DialogTitle id="alert-dialog-title">
+          Leave The Lavender Book?
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText id="alert-dialog-description">
+            Are you sure you want to leave The Lavender Book? You will be taken
+            to Google Forms to contact Support.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setShowSupportDialog(false)} color="primary">
+            Disagree
+          </Button>
+          <Button
+            onClick={() => {
+              window.open('https://forms.gle/mLDNTMGxMojuiKKLA', '_blank');
+              setShowSupportDialog(false);
+            }}
+            color="primary"
+            autoFocus
+          >
+            Agree
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+};
+
+SupportButton.propTypes = {};
+
+SupportButton.defaultProps = {};
+
+export default withStyles(styles)(SupportButton);

--- a/src/components/SupportButton/SupportButton.md
+++ b/src/components/SupportButton/SupportButton.md
@@ -1,0 +1,5 @@
+## SupportButton
+
+```jsx
+<SupportButton />
+```

--- a/src/components/SupportButton/SupportButton.test.jsx
+++ b/src/components/SupportButton/SupportButton.test.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { screen, render } from '@testing-library/react';
+
+import SupportButton from './SupportButton';
+
+describe('SupportButton', () => {
+  it('It should render a correct label', () => {
+    render(<SupportButton />);
+    const button = screen.getByText('Report a Problem');
+    expect(button).toBeInTheDocument();
+  });
+});

--- a/src/components/SupportButton/index.js
+++ b/src/components/SupportButton/index.js
@@ -1,0 +1,3 @@
+import SupportButton from './SupportButton';
+
+export default SupportButton;

--- a/src/routes/Search/Search.jsx
+++ b/src/routes/Search/Search.jsx
@@ -22,6 +22,7 @@ import FilterPanel from '../../components/FilterPanel';
 import Pagination from '../../components/Pagination';
 import useSearch from './hooks/useSearch';
 import SearchForm from './SearchForm';
+import SupportButton from '../../components/SupportButton/SupportButton';
 
 const styles = () => ({
   content: {
@@ -488,6 +489,7 @@ const Search = ({
                 page={pagination.page || 1}
                 perPage={pagination.perPage || 10}
               />
+              <SupportButton />
             </div>
           )}
         </div>


### PR DESCRIPTION
# Description
This PR adds the SupportButton component from PR #74 to the Search Page. As based on the Figma designed there's also one at the bottom of the search results page. 

- Opening the prompt to go to a page no longer influences the page height when opened. You can see this effect in the before/after where before it'd push the range downwards when opened.
- Support Button added to bottom of Search Page

## Screenshots
**Before**
![Code_43pNnbmCgO](https://user-images.githubusercontent.com/86702974/212249771-b2282d76-8a14-428d-8fd0-dcb6198275c8.png)


**After**
![Code_GQHeeS6Ua1](https://user-images.githubusercontent.com/86702974/212249781-8855fa74-d212-4042-afa8-b97903ab9a0b.png)
![Code_n8XjatPZm4](https://user-images.githubusercontent.com/86702974/212249736-a213eadf-3e70-448c-b84d-55cb693bacd8.png)
![Code_kSsMCLTVHK](https://user-images.githubusercontent.com/86702974/212249747-c6c81250-b16d-4e93-94cf-f95d577db558.png)
![Code_UupYtn5Y3o](https://user-images.githubusercontent.com/86702974/212249754-da798680-9f15-4409-a30a-2bf71ecae38c.png)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tried it on mobile and desktop to make sure all the components aligned properly. It was just 1 line css change and adding one existing component so I didn't think it needed an specific tests.
